### PR TITLE
Fix string data in JST

### DIFF
--- a/lib/gmo-pg/http_resource/payload/typecast.rb
+++ b/lib/gmo-pg/http_resource/payload/typecast.rb
@@ -72,14 +72,16 @@ module GMO
               @value
             when DateTime
               Time.new(@value.year, @value.month, @value.day, @value.hour, @value.min, @value.sec)
+            when String
+              Time.strptime("#{@value} #{TIME_ZONE}", "#{FORMAT} %:z") rescue super
             else
-              Time.strptime(@value, format) rescue return super
+              super
             end
           time.to_i rescue super
         end
 
         def to_payload
-          Time.at(to_attribute).localtime(TIME_ZONE).strftime(format) rescue super
+          Time.at(to_attribute).strftime(format) rescue super
         end
       end
     end

--- a/spec/gmo-pg/http_resource/payload/typecast_spec.rb
+++ b/spec/gmo-pg/http_resource/payload/typecast_spec.rb
@@ -158,7 +158,7 @@ describe GMO::PG::Payload::TypecastableEpochTime do
           epoch_time = Time.new(2017, 1, 2, 12, 34, 56).to_i
           expect(GMO::PG::Payload::TypecastableEpochTime.new(Time.at(epoch_time)).to_attribute).to eq epoch_time
           expect(GMO::PG::Payload::TypecastableEpochTime.new(DateTime.new(2017, 1, 2, 12, 34, 56)).to_attribute).to eq epoch_time
-          expect(GMO::PG::Payload::TypecastableEpochTime.new('20170102123456').to_attribute).to eq epoch_time
+          expect(GMO::PG::Payload::TypecastableEpochTime.new('20170102213456').to_attribute).to eq epoch_time
           expect(GMO::PG::Payload::TypecastableEpochTime.new(epoch_time).to_attribute).to eq epoch_time
         end
       end
@@ -176,10 +176,10 @@ describe GMO::PG::Payload::TypecastableEpochTime do
       it 'returns string value' do
         in_timezone 'UTC' do
           epoch_time = Time.new(2017, 1, 2, 12, 34, 56).to_i
-          expected_value = Time.at(epoch_time).localtime('+09:00').strftime('%Y%m%d%H%M%S')
+          expected_value = '20170102123456'
           expect(GMO::PG::Payload::TypecastableEpochTime.new(Time.at(epoch_time)).to_payload).to eq expected_value
           expect(GMO::PG::Payload::TypecastableEpochTime.new(DateTime.new(2017, 1, 2, 12, 34, 56)).to_payload).to eq expected_value
-          expect(GMO::PG::Payload::TypecastableEpochTime.new('20170102123456').to_payload).to eq expected_value
+          expect(GMO::PG::Payload::TypecastableEpochTime.new('20170102213456').to_payload).to eq expected_value
           expect(GMO::PG::Payload::TypecastableEpochTime.new(epoch_time).to_payload).to eq expected_value
         end
       end


### PR DESCRIPTION
GMO API returns date value as JST string. I use 'tokyo' time zone in my rails.
But the changed time is utc So this difference causes a time lag in my app.

If incompatible with the existing operation is problem, you may want to let the user select the other in the configuration options something like this:

```rb
# config
GMO::PG.timezone = 'UTC' # or 'JST'
```